### PR TITLE
Add a copyable Wget command to recursively clone the current directory

### DIFF
--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -5,10 +5,9 @@ if ($deploy_path = "") {
 }
 
 # The MeowIndex web app block
-location /__meowindex__ {
-    alias /etc/nginx/MeowIndex/dist;
+location ^~ /__meowindex__/ {
+    alias /etc/nginx/MeowIndex/dist/;
 
-    # Use sub_filter to configure the app
     sub_filter_types application/javascript text/javascript;
     sub_filter_once off;
     sub_filter "{ASSETS-PATH-PLACEHOLDER}" "/__meowindex__";
@@ -17,13 +16,12 @@ location /__meowindex__ {
     sub_filter "\"/assets" "\"/__meowindex__/assets";
     sub_filter "File Listing" $title;
 
-    # Serve index.html on other 404 paths as well
     try_files $uri /__meowindex__/index.html;
 }
 
-# Endpoint to recursively clone with wget
-location /raw {
-    alias $dir_path;
+# Endpoint for recursive wget clone
+location ^~ /raw/ {
+    alias $dir_path/;
     index DISABLE_INDEX_HTML_AUTO_MATCHING;
 
     autoindex on;
@@ -32,12 +30,20 @@ location /raw {
     autoindex_localtime on;
 }
 
+location = /raw {
+    return 301 /raw/;
+}
+
 # The api block
-location /api {
-    alias $dir_path;
+location ^~ /api/ {
+    alias $dir_path/;
     index DISABLE_INDEX_HTML_AUTO_MATCHING;
 
     autoindex on;
     autoindex_format json;
     add_header Access-Control-Allow-Origin *;
+}
+
+location = /api {
+    return 301 /api/;
 }

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -21,6 +21,17 @@ location /__meowindex__ {
     try_files $uri /__meowindex__/index.html;
 }
 
+# Endpoint to recursively clone with wget
+location /raw {
+    alias $dir_path;
+    index DISABLE_INDEX_HTML_AUTO_MATCHING;
+
+    autoindex on;
+    autoindex_format html;
+    autoindex_exact_size off;
+    autoindex_localtime on;
+}
+
 # The api block
 location /api {
     alias $dir_path;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,24 +158,6 @@ export default function App() {
           </div>
         </div>
 
-        {/* Wget clone command */}
-        <div class="bg-dark-600 p-3 px-5 mb-5 rounded-xl">
-          <div class="opacity-50 mb-2">Download with wget:</div>
-
-          <div class="flex gap-2 items-center">
-            <code class="flex-1 overflow-x-auto whitespace-nowrap bg-dark-800 rounded-lg p-2">
-              {getWgetCommand()}
-            </code>
-
-            <button
-              class="bg-dark-300 hover:bg-dark-200 rounded-lg px-3 py-2 transition-all"
-              onClick={copyWget}
-            >
-              {copiedWget() ? "Copied" : "Copy"}
-            </button>
-          </div>
-        </div>
-
         {/* Breadcrumb slot */}
         <div id="breadcrumbs" class="flex bg-dark-600 p-2 px-5 mb-5 rounded-xl whitespace-nowrap relative z-30">
           <Icon icon="ion:wifi-outline" class="text-xl mr-2"/>
@@ -204,6 +186,22 @@ export default function App() {
           </Show>
 
           <Icon icon="ion:search-outline" class="text-xl ml-2" onclick={e => searchOn() ? searchDeactivate() : searchActivate()}/>
+        </div>
+
+        {/* Wget clone command */}
+        <div class="bg-dark-600 p-3 px-5 mb-5 rounded-xl">
+          <div class="flex gap-2 items-center">
+            <code class="flex-1 overflow-x-auto whitespace-nowrap bg-dark-800 rounded-lg p-2">
+              {getWgetCommand()}
+            </code>
+
+            <button
+              class="bg-dark-300 hover:bg-dark-200 rounded-lg px-3 py-2 transition-all"
+              onClick={copyWget}
+            >
+              {copiedWget() ? "Copied" : "Copy"}
+            </button>
+          </div>
         </div>
 
         {/*{api.loading && "Loading..."}*/}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,19 @@ function getHref(f: File)
   // return urlJoin(fullPath, f.name)
 }
 
+function getWgetCommand()
+{
+  const path = filePath.endsWith("/") ? filePath : `${filePath}/`
+  const rawPath = urlJoin("/raw", path) + "/"
+
+  // Preserve the current folder name.
+  // Example:
+  // /raw/projects/foo/ with --cut-dirs=2 gives ./foo/...
+  const cutDirs = Math.max(0, rawPath.split("/").filter(Boolean).length - 1)
+
+  return `wget -rnpnH --cut-dirs=${cutDirs} -R 'index.html*' ${window.location.origin}${rawPath}`
+}
+
 const alpNum = new Set("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 export default function App() {
@@ -74,6 +87,14 @@ export default function App() {
   // Infinite Scroll
   const [scrollIndex, setScrollIndex] = createSignal(50)
   const scrollNext = () => setScrollIndex(Math.min(scrollIndex() + 20, api().length))
+
+  // Wget command
+  const [copiedWget, setCopiedWget] = createSignal(false)
+  const copyWget = async () => {
+    await navigator.clipboard.writeText(getWgetCommand())
+    setCopiedWget(true)
+    setTimeout(() => setCopiedWget(false), 1200)
+  }
 
   // Search
   let searchInp: HTMLInputElement
@@ -134,6 +155,24 @@ export default function App() {
               Powered by Nginx MeowIndex
               <Icon class="text-lg" icon="mdi:github"/>
             </a>
+          </div>
+        </div>
+
+        {/* Wget clone command */}
+        <div class="bg-dark-600 p-3 px-5 mb-5 rounded-xl">
+          <div class="opacity-50 mb-2">Download with wget:</div>
+
+          <div class="flex gap-2 items-center">
+            <code class="flex-1 overflow-x-auto whitespace-nowrap bg-dark-800 rounded-lg p-2">
+              {getWgetCommand()}
+            </code>
+
+            <button
+              class="bg-dark-300 hover:bg-dark-200 rounded-lg px-3 py-2 transition-all"
+              onClick={copyWget}
+            >
+              {copiedWget() ? "Copied" : "Copy"}
+            </button>
           </div>
         </div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,7 +75,7 @@ function getWgetCommand()
   // /raw/projects/foo/ with --cut-dirs=2 gives ./foo/...
   const cutDirs = Math.max(0, rawPath.split("/").filter(Boolean).length - 1)
 
-  return `wget -rnpnH --cut-dirs=${cutDirs} -R 'index.html*' ${window.location.origin}${rawPath}`
+  return `wget -r -np -nH -e robots=off -nc --cut-dirs=${cutDirs} \ ${window.location.origin}${rawPath}`
 }
 
 const alpNum = new Set("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,14 +68,14 @@ function getHref(f: File)
 function getWgetCommand()
 {
   const path = filePath.endsWith("/") ? filePath : `${filePath}/`
-  const rawPath = urlJoin("/raw", path) + "/"
+  const rawPath = urlJoin("/raw", path)
 
   // Preserve the current folder name.
   // Example:
   // /raw/projects/foo/ with --cut-dirs=2 gives ./foo/...
   const cutDirs = Math.max(0, rawPath.split("/").filter(Boolean).length - 1)
 
-  return `wget -r -np -nH -e robots=off -nc --cut-dirs=${cutDirs} \ ${window.location.origin}${rawPath}`
+  return `wget -r -np -nH -e robots=off -nc --cut-dirs=${cutDirs} ${window.location.origin}${rawPath}`
 }
 
 const alpNum = new Set("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")


### PR DESCRIPTION
I really liked the tool you made but one of my requirements was to provide an easy way to clone the current dir. I added the `/raw` endpoint to the nginx config and also slightly improved the config itself. In `App.tsx` it now builds a command with [wget](https://www.gnu.org/software/wget/) and displays it with a copy button. Im not a web dev and did not have the time to implement a config to turn it on/off, so help with this would be appreciated.

Have a nice day!

<img width="792" height="328" alt="Screenshot 2569-06-10 at 10 09 01" src="https://github.com/user-attachments/assets/7e5292a0-16f2-4912-8a79-ffbdbea6f4ef" />